### PR TITLE
PT-8886 Prefix set on profile classes

### DIFF
--- a/Components/Migration/Profile.php
+++ b/Components/Migration/Profile.php
@@ -78,7 +78,7 @@ abstract class Profile extends Enlight_Class
             $this->db->setProfiler(new Profiler(true, $this->db));
         }
 
-        if (isset($config['prefix'])) {
+        if (isset($options['prefix'])) {
             $this->db_prefix = $options['prefix'];
         }
     }


### PR DESCRIPTION
Correcting variable allows db prefix to be set rather than always ignored.

Original problem can be recreated by attempting to start a migration for a Magento 1 shop (others are likely affected too - this is an example) that uses a table prefix. Set the prefix in the interface and press next. Expected: proceed to next form to map attributes. Actual: PHP error